### PR TITLE
fix(Docker): install dev dependencies even for a prod build

### DIFF
--- a/generators/base/templates/Dockerfile
+++ b/generators/base/templates/Dockerfile
@@ -68,8 +68,7 @@ RUN set -ex; \
     yarn install \
       --frozen-lockfile \
       --ignore-scripts \
-      --no-cache \
-      --production; \
+      --no-cache; \
   elif [ "$BUILD_ENV" = "test" ]; then \
     yarn install \
       --frozen-lockfile \


### PR DESCRIPTION
Since we run `yarn run build` next, we need them.