### PR TITLE
chore: tag hadolint image

### DIFF
--- a/generators/circleci/templates/circleci/config-workflow-docker.yml
+++ b/generators/circleci/templates/circleci/config-workflow-docker.yml
@@ -142,7 +142,7 @@ jobs:
   dockerfile-lint:
     <<: *defaults
     docker:
-      - image: hadolint/hadolint
+      - image: hadolint/hadolint:v1.6.6-6-g254b4ff
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
Resolves #10 
Adds the `:1.6.6-6-g254b4ff` tag to the hadolint image.

@ticean is this how you'd like to resolve this for now?