### PR TITLE
fix: fix reactioncommerce link typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "generator-reaction",
   "version": "0.0.0-development",
   "description": "Project generator for Reaction NodeJS projects. Built with Yeoman.",
-  "homepage": "https://github.com/rectioncommerce/generator-reaction",
+  "homepage": "https://github.com/reactioncommerce/generator-reaction",
   "author": {
     "name": "Reaction Commerce",
     "email": "hello@reactioncommerce.com",


### PR DESCRIPTION
## Bug
<img width="1238" alt="screen shot 2018-07-02 at 1 28 35 pm" src="https://user-images.githubusercontent.com/3673236/42184896-eded57c8-7dfb-11e8-9649-495dbfcbdd51.png">

Searching for and clicking on Reaction's generator on Yeoman's site leads to  https://github.com/rectioncommerce/generator-reaction instead of https://github.com/reactioncommerce/generator-reaction

## Solution
- Update the link in package.json's homepage value

Fixing this typo will fix this bug on http://yeoman.io/generators/, where searching for and clicking on Reaction's generator leads to https://github.com/rectioncommerce/generator-reaction instead

