### PR TITLE
chore: Rename the reaction-api Docker network

### DIFF
--- a/generators/backend/templates/docker-compose.yml
+++ b/generators/backend/templates/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.4'
 
 networks:
-  reaction-api:
+  graphql:
     external:
-      name: reaction-api
+      name: graphql.reaction.localhost
 
 services:
   web:
@@ -17,7 +17,7 @@ services:
     environment:
       REACTION_APP_NAME: "<%= projectName %>.web"
     networks:
-      reaction-api:
+      graphql:
         aliases:
           - <%= projectName %>
     ports:

--- a/generators/backend/templates/docker-compose.yml
+++ b/generators/backend/templates/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.4'
 
 networks:
-  graphql:
+  api:
     external:
-      name: graphql.reaction.localhost
+      name: api.reaction.localhost
 
 services:
   web:
@@ -17,7 +17,7 @@ services:
     environment:
       REACTION_APP_NAME: "<%= projectName %>.web"
     networks:
-      graphql:
+      api:
         aliases:
           - <%= projectName %>
     ports:

--- a/generators/frontend/templates/docker-compose.yml
+++ b/generators/frontend/templates/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.4'
 
 networks:
-  reaction-api:
+  graphql:
     external:
-      name: reaction-api
+      name: graphql.reaction.localhost
 
 services:
   web:
@@ -17,7 +17,7 @@ services:
     environment:
       REACTION_APP_NAME: "<%= projectName %>.web"
     networks:
-      reaction-api:
+      graphql:
         aliases:
           - <%= projectName %>
     ports:

--- a/generators/frontend/templates/docker-compose.yml
+++ b/generators/frontend/templates/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.4'
 
 networks:
-  graphql:
+  api:
     external:
-      name: graphql.reaction.localhost
+      name: api.reaction.localhost
 
 services:
   web:
@@ -17,7 +17,7 @@ services:
     environment:
       REACTION_APP_NAME: "<%= projectName %>.web"
     networks:
-      graphql:
+      api:
         aliases:
           - <%= projectName %>
     ports:


### PR DESCRIPTION
Renames the Docker network on which the GraphQL enabled web services are attached.

Networks in the Docker environment should be named as *.reaction.localhost. The localhost TLD is reserved and guaranteed to not conflict with a real TLD.

ref: https://github.com/reactioncommerce/reaction/issues/4447

## Merge Considerations

* The network is only updated in newly created projects.
* To enable network communication, other projects must use this new network name.
* PRs related to https://github.com/reactioncommerce/reaction/issues/4447 should be coordinated.