### PR TITLE
Improve Composability and Expose Generators

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -5,9 +5,9 @@ const yosay = require('yosay');
 
 module.exports = class extends Generator {
   initializing() {
-    // Pass this.props by reference to child generators so that when we
+    // Pass props by reference to child generators so that when we
     // mutate them with prompt answers, the children can see them.
-    this.props = {};
+    this.options.props = this.options.props || {};
 
     const backendGenerator = require.resolve('../backend');
     const baseGenerator = require.resolve('../base');
@@ -20,17 +20,25 @@ module.exports = class extends Generator {
     this.env.register(circleGenerator, 'reaction:circleci');
 
     // Run these generators in order.
-    this.composeWith(baseGenerator, { props: this.props });
-    this.composeWith(backendGenerator, { props: this.props });
-    this.composeWith(frontendGenerator, { props: this.props });
-    this.composeWith(docsGenerator, { props: this.props });
-    this.composeWith(circleGenerator, { props: this.props });
+    this.composeWith(baseGenerator, { props: this.options.props });
+    this.composeWith(backendGenerator, { props: this.options.props });
+    this.composeWith(frontendGenerator, { props: this.options.props });
+    this.composeWith(docsGenerator, { props: this.options.props });
+    this.composeWith(circleGenerator, { props: this.options.props });
   }
 
   prompting() {
-    this.log(yosay('Welcome to the excellent ' + chalk.red('reaction') + ' generator!'));
+    this.options.props = this.options.props || {};
 
-    const prompts = [
+    // Capture all provided option params into the props context.
+    // Allows user to define settings at the command line.
+    Object.keys(this.options).forEach(key => {
+      this.options.props[key] = this.options[key];
+    });
+
+    this.log(yosay('Welcome to the ' + chalk.red('reaction') + ' generator.'));
+
+    var prompts = [
       {
         message: 'Project Name',
         name: 'projectName',
@@ -58,9 +66,8 @@ module.exports = class extends Generator {
     ];
 
     return this.prompt(prompts).then(props => {
-      // We must mutate this.props here so that all composed generators can see
       Object.keys(props).forEach(key => {
-        this.props[key] = props[key];
+        this.options.props[key] = props[key];
       });
     });
   }

--- a/generators/base/index.js
+++ b/generators/base/index.js
@@ -5,39 +5,71 @@ const rimraf = require('rimraf');
 
 module.exports = class extends Generator {
   prompting() {
-    const prompts = [
+    this.options.props = this.options.props || {};
+
+    var prompts = [
+      {
+        message: 'Project Name',
+        name: 'projectName',
+        type: 'input',
+        validate(value) {
+          if (typeof value !== 'string' || value.length === 0)
+            return 'Project name is required!';
+          if (value.indexOf(' ') > -1) return 'No spaces allowed!';
+          return true;
+        },
+        when: () => !Object.keys(this.options.props).includes('projectName')
+      },
+      {
+        choices: ['frontend', 'backend'],
+        message: 'Project Type',
+        name: 'projectType',
+        type: 'list',
+        validate(value) {
+          if (typeof value !== 'string' || value.length === 0)
+            return 'You must choose a project type!';
+          return true;
+        },
+        when: () => !Object.keys(this.options.props).includes('projectType')
+      },
       {
         default: '0.1.0',
         message: 'Version',
         name: 'projectVersion',
-        type: 'input'
+        type: 'input',
+        when: () => !Object.keys(this.options.props).includes('projectVersion')
       },
       {
         message: 'Description',
         name: 'projectDescription',
-        type: 'input'
+        type: 'input',
+        when: () => !Object.keys(this.options.props).includes('projectDescription')
       },
       {
         message: 'Keywords',
         name: 'projectKeywords',
-        type: 'input'
+        type: 'input',
+        when: () => !Object.keys(this.options.props).includes('projectKeywords')
       },
       {
         default: 'Reaction Commerce',
         message: 'Author',
         name: 'projectAuthor',
-        type: 'input'
+        type: 'input',
+        when: () => !Object.keys(this.options.props).includes('projectAuthor')
       },
       {
         default: 'hello@reactioncommerce.com',
         message: 'Author Email',
         name: 'projectAuthorEmail',
-        type: 'input'
+        type: 'input',
+        when: () => !Object.keys(this.options.props).includes('projectAuthorEmail')
       },
       {
         message: 'Keep NPM repository private?',
         name: 'isNPMPrivate',
-        type: 'confirm'
+        type: 'confirm',
+        when: () => !Object.keys(this.options.props).includes('isNPMPrivate')
       }
     ];
 

--- a/generators/circleci/index.js
+++ b/generators/circleci/index.js
@@ -3,7 +3,9 @@ const Generator = require('yeoman-generator');
 
 module.exports = class extends Generator {
   prompting() {
-    const { projectName } = this.options.props || {};
+    this.options.props = this.options.props || {};
+
+    const { projectName } = this.options.props;
     const defaultDockerRepository = projectName
       ? `reactioncommerce/${projectName}`
       : null;
@@ -13,17 +15,19 @@ module.exports = class extends Generator {
         default: defaultDockerRepository,
         message: 'Docker repository.',
         name: 'dockerRepository',
-        type: 'input'
+        type: 'input',
+        when: () => !Object.keys(this.options.props).includes('dockerRepository')
       },
       {
         message: 'Is Docker repo private?',
         name: 'isDockerPrivate',
-        type: 'confirm'
+        type: 'confirm',
+        when: () => !Object.keys(this.options.props).includes('isDockerPrivate')
       }
     ];
 
     return this.prompt(prompts).then(props => {
-      // We must mutate this.options.props here so that all composed generators can see
+      // Mutate this.options.props to share with composed generators.
       Object.keys(props).forEach(key => {
         this.options.props[key] = props[key];
       });

--- a/generators/npm/index.js
+++ b/generators/npm/index.js
@@ -19,7 +19,8 @@ module.exports = class extends Generator {
             return 'NPM package names must be in the "@reactioncommerce" scope';
           }
           return true;
-        }
+        },
+        when: () => !Object.keys(this.options.props).includes('packageName')
       }
     ]);
     Object.assign(this.templateVariables, answers);
@@ -34,7 +35,8 @@ module.exports = class extends Generator {
             return 'You must enter a package description!';
           }
           return true;
-        }
+        },
+        when: () => !Object.keys(this.options.props).includes('packageDescription')
       }
     ]);
     Object.assign(this.templateVariables, answers);
@@ -50,7 +52,8 @@ module.exports = class extends Generator {
             return 'You must enter a repository name!';
           }
           return true;
-        }
+        },
+        when: () => !Object.keys(this.options.props).includes('repoName')
       }
     ]);
     Object.assign(this.templateVariables, answers);


### PR DESCRIPTION
Exposes sub generators so that they can be run independently of the main generator. This provides flexibility to pull in a small part of generated code without having to buy into a whole project. 

Subgenerators can be used to start a project, or append granular functionality into an existing one.

#### New Tasks

* `yo reaction:circleci`
* `yo reaction:docs`

After this PR, we can put thought into which functionality to extract into sub generators and expose.

### CLI Options
CLI options are also now supported and will be merged into the context. Options provided on the CLI will supersede prompts. Prompts will not appear for those options.

Example usage:

yo reaction --project-name my-project --project-type backend [...]