### PR TITLE
fix: Fix shellcheck errors and autoformat scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2
 jobs:
   lint-shell-scripts:
     docker:
@@ -47,7 +47,7 @@ jobs:
       - run: npx semantic-release
 
 workflows:
-  version: 2.1
+  version: 2
   build_deploy:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,20 @@
-
-version: 2
+version: 2.1
 jobs:
+  lint-shell-scripts:
+    docker:
+      - image: docker:18.09-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Lint Shell Scripts
+          command: |
+            find generators -path '*/bin/*' | {
+              while IFS= read -r file_path; do
+                echo "shellcheck ${file_path}"
+                docker run --rm --interactive koalaman/shellcheck:v0.6.0 -x /dev/stdin < "${file_path}"
+              done
+            }
   build:
     docker:
       - image: node:8
@@ -17,7 +31,6 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm run test
-
       - save_cache:
           paths:
             - node_modules
@@ -34,11 +47,13 @@ jobs:
       - run: npx semantic-release
 
 workflows:
-  version: 2
+  version: 2.1
   build_deploy:
     jobs:
       - build:
           context: reaction-publish-semantic-release
+          requires:
+            - lint-shell-scripts
       - deploy:
           context: reaction-publish-semantic-release
           requires:
@@ -46,3 +61,4 @@ workflows:
           filters:
             branches:
               only: master
+      - lint-shell-scripts

--- a/generators/base/templates/bin/setup
+++ b/generators/base/templates/bin/setup
@@ -4,27 +4,29 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 env_file=${__dir}/../.env
 env_example_file=${__dir}/../.env.example
 
-function main {
+function main() {
   set -e
 
   add_new_env_vars
 }
 
-function add_new_env_vars {
+function add_new_env_vars() {
   # create .env and set perms if it does not exist
-  [ ! -f "${env_file}" ] && { touch "${env_file}" ; chmod 0600 "${env_file}" ; }
+  [ ! -f "${env_file}" ] && {
+    touch "${env_file}"
+    chmod 0600 "${env_file}"
+  }
 
-  export IFS=$'\n'
-  for var in $(cat "${env_example_file}"); do
-    key="${var%%=*}"     # get var key
+  while IFS= read -r var; do
+    key="${var%%=*}"        # get var key
     var=$(eval echo "$var") # generate dynamic values
 
     # If .env doesn't contain this env key, add it
-    if ! $(grep -qLE "^$key=" "${env_file}"); then
+    if ! grep -qLE "^$key=" "${env_file}"; then
       echo "Adding $key to .env"
-      echo "$var" >> "${env_file}"
+      echo "$var" >>"${env_file}"
     fi
-  done
+  done <"${env_example_file}"
 }
 
 main

--- a/generators/base/templates/bin/yarn-link
+++ b/generators/base/templates/bin/yarn-link
@@ -38,5 +38,5 @@ for module in ${custom_modules}; do
   yarn --modules-folder "${modules_folder}" link
   cd "${project_folder}" \
     || ( echo "Project directory doesn't exist while NPM module linking!" 2>&1 && exit 1 )
-  yarn --modules-folder "${modules_folder}" link ${module}
+  yarn --modules-folder "${modules_folder}" link "${module}"
 done


### PR DESCRIPTION
I tested the `setup` changes. The `yarn-link` change should be correct but if I'm misunderstanding it maybe we do want word splitting in `${module}`.